### PR TITLE
Add `ensure` parameter to `::autofs::mapfile`

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,6 +1,6 @@
 fixtures:
-  repositories:
-    "stdlib": "git://github.com/puppetlabs/puppetlabs-stdlib.git"
-    "concat": "git://github.com/puppetlabs/puppetlabs-concat.git"
+  forge_modules:
+    stdlib: "puppetlabs/stdlib"
+    concat: "puppetlabs/concat"
   symlinks:
-    "ntp": "#{source_dir}"
+    autofs: "#{source_dir}"

--- a/manifests/mapfile.pp
+++ b/manifests/mapfile.pp
@@ -1,6 +1,7 @@
 #
 define autofs::mapfile(
   $directory,
+  $ensure   = present,
   $mapfile  = $name,
   $options  = undef,
   $order    = undef,
@@ -10,19 +11,36 @@ define autofs::mapfile(
   validate_string($options)
   validate_hash($mounts)
 
+  validate_re($ensure, '^present$|^absent$|^purged$', 'ensure must be one of: present, absent, or purged')
+
   include ::autofs
 
   if $mapfile != $autofs::master_config {
     validate_absolute_path($directory)
 
-    concat::fragment { "${autofs::master_config}/${mapfile}":
-      target  => $autofs::master_config,
-      content => "${directory} ${mapfile} ${options}",
-      order   => $order;
+    if $ensure == present {
+      concat::fragment { "${autofs::master_config}/${mapfile}":
+        target  => $autofs::master_config,
+        content => "${directory} ${mapfile} ${options}",
+        order   => $order;
+      }
     }
   }
 
+  if $ensure == purged {
+    $concat_ensure = absent
+    # purge the directory after autofs has been restarted
+    file { $directory:
+      ensure  => absent,
+      force   => true,
+      require => Class['autofs::service'],
+    }
+  } else {
+    $concat_ensure = $ensure
+  }
+
   concat { $mapfile:
+    ensure         => $concat_ensure,
     owner          => $autofs::config_file_owner,
     group          => $autofs::config_file_group,
     path           => "${autofs::map_config_dir}/${mapfile}",

--- a/spec/defines/autofs__mapfile_spec.rb
+++ b/spec/defines/autofs__mapfile_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+describe 'autofs::mapfile' do
+  let(:title) { 'auto.foo' }
+  let(:facts) {{ :osfamily => 'RedHat', :concat_basedir => '/mock_dir' }}
+
+  describe 'passing something other than present, absent, or purged for ensure' do
+      let(:params) {{ :directory => '/foo' , :ensure => 'foo' }}
+      it { should raise_error(Puppet::Error, /ensure must be one of/) }
+  end
+
+  describe 'passing present for ensure' do
+      let(:params) {{ :directory => '/foo' , :ensure => 'present' }}
+      it { should_not raise_error }
+      it {
+          should contain_concat__fragment('auto.master/auto.foo').
+          with_content(/\/foo auto.foo/)
+      }
+      it {
+          should contain_concat('auto.foo').
+          with_ensure('present')
+      }
+  end
+
+  describe 'passing absent for ensure' do
+      let(:params) {{ :directory => '/foo' , :ensure => 'absent' }}
+      it { should_not raise_error }
+      it {
+          should_not contain_concat__fragment('auto.master/auto.foo')
+      }
+      it {
+          should contain_concat('auto.foo').
+          with_ensure('absent')
+      }
+  end
+
+  describe 'passing purged for ensure' do
+      let(:params) {{ :directory => '/foo' , :ensure => 'purged' }}
+      it { should_not raise_error }
+      it {
+          should_not contain_concat__fragment('auto.master/auto.foo')
+      }
+      it {
+          should contain_concat('auto.foo').
+          with_ensure('absent')
+      }
+      it {
+          should contain_file('/foo').
+          with({
+              'ensure' => 'absent',
+              'force'  => true,
+          })
+      }
+  end
+
+end
+

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'puppetlabs_spec_helper/module_spec_helper'
+
+RSpec.configure do |c|
+  c.before do
+    # avoid "Only root can execute commands as other users"
+    Puppet.features.stubs(:root? => true)
+  end
+end


### PR DESCRIPTION
The new `ensure` parameter defaults to `present`, which is the current functionality.

`absent` or `purged` allow cleanup of no-longer-needed autofs map files:

`absent` just makes sure the autofs mapfile itself is removed:

    # Make sure the /foobar entry does not exist in auto.master
    # and remove the auto.foobar map file
    ::autofs::mapfile { 'auto.foobar':
      ensure    => absent,
      directory => '/foobar',
    }

`purged` also removes the mountpoint directory:

    # Make sure the /quux entry does not exist in auto.master,
    # remove the auto.quux map file, and remove the /quux
    # directory
    ::autofs::mapfile { 'auto.quux':
      ensure    => purged,
      directory => '/quux',
    }

Also created spec tests for this change.