### PR TITLE
Add `maptype` parameter for a mapfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,14 @@ autofs::service_restart: '/usr/bin/systemctl reload autofs'
   directory => '/home',
 ```
 
+### Added a map file with a non-'file' type
+```puppet
+::autofs::mapfile{ 'auto.chroot':
+  directory => '/chroot',
+  maptype   => program ,
+}
+```
+
 ### Include an other master config
 ```puppet
 ::autofs::include{ 'auto.local': }

--- a/manifests/mapfile.pp
+++ b/manifests/mapfile.pp
@@ -5,15 +5,34 @@ define autofs::mapfile(
   $mapfile  = $name,
   $options  = undef,
   $order    = undef,
+  $maptype  = 'file' ,
   $mounts   = {}
 ) {
+
+  include ::autofs
+
   validate_string($mapfile)
   validate_string($options)
   validate_hash($mounts)
 
   validate_re($ensure, '^present$|^absent$|^purged$', 'ensure must be one of: present, absent, or purged')
 
-  include ::autofs
+  # surround $supported_map_types list items with ^...$ for regular expression matching
+  $supported_map_types_re = regsubst($::autofs::supported_map_types, '^.*$', '^\0$')
+  # join $supported_map_types list with commas, put an 'or' before the
+  # last supported type, and remove the comma if only two items in list.
+  $supported_map_types_str = regsubst(regsubst(join($::autofs::supported_map_types, ', '), ', ([^,]*)$', ', or \1'), '^([^,]*),( or [^,]*)$', '\1\2')
+  # check $maptype is valid
+  validate_re($maptype, $supported_map_types_re, "maptype must be one of: ${supported_map_types_str}")
+
+  # $mapfile_prefix is equal to "${maptype}:", _unless_:
+  # 1)  $maptype == 'file'
+  # 2)  $use_map_prefix is false
+  if $maptype != 'file' and $::autofs::use_map_prefix {
+    $mapfile_prefix = "${maptype}:"
+  } else {
+    $mapfile_prefix = ''
+  }
 
   if $mapfile != $autofs::master_config {
     validate_absolute_path($directory)
@@ -21,7 +40,7 @@ define autofs::mapfile(
     if $ensure == present {
       concat::fragment { "${autofs::master_config}/${mapfile}":
         target  => $autofs::master_config,
-        content => "${directory} ${mapfile} ${options}",
+        content => "${directory} ${mapfile_prefix}${mapfile} ${options}",
         order   => $order;
       }
     }
@@ -39,19 +58,22 @@ define autofs::mapfile(
     $concat_ensure = $ensure
   }
 
-  concat { $mapfile:
-    ensure         => $concat_ensure,
-    owner          => $autofs::config_file_owner,
-    group          => $autofs::config_file_group,
-    path           => "${autofs::map_config_dir}/${mapfile}",
-    mode           => '0644',
-    warn           => true,
-    ensure_newline => true,
-    notify         => Class['autofs::service'],
-    require        => Class['autofs::install'],
-  }
+  # Only create the mapfile and any mounts if $maptype == file
+  if $maptype == 'file' {
+    concat { $mapfile:
+      ensure         => $concat_ensure,
+      owner          => $autofs::config_file_owner,
+      group          => $autofs::config_file_group,
+      path           => "${autofs::map_config_dir}/${mapfile}",
+      mode           => '0644',
+      warn           => true,
+      ensure_newline => true,
+      notify         => Class['autofs::service'],
+      require        => Class['autofs::install'],
+    }
 
-  create_resources('autofs::mount', $mounts, {
-    map => $mapfile
-  })
+    create_resources('autofs::mount', $mounts, {
+      map => $mapfile
+    })
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,54 +10,64 @@ class autofs::params {
 
   case $::osfamily {
     'Debian': {
-      $config_file_group  = 'root'
-      $config_file_owner  = 'root'
-      $master_config      = 'auto.master'
-      $map_config_dir     = '/etc'
-      $package_name       = [ 'autofs-ldap' ]
-      $service_name       = 'autofs'
-      $service_hasrestart = true
-      $service_hasstatus  = true
+      $config_file_group   = 'root'
+      $config_file_owner   = 'root'
+      $master_config       = 'auto.master'
+      $map_config_dir      = '/etc'
+      $package_name        = [ 'autofs-ldap' ]
+      $service_name        = 'autofs'
+      $service_hasrestart  = true
+      $service_hasstatus   = true
+      $supported_map_types = [ 'file', 'program', 'yp', 'nisplus', 'hesiod', 'ldap', 'ldaps' ]
+      $use_map_prefix      = true
     }
     'Solaris': {
-      $config_file_group  = 'root'
-      $config_file_owner  = 'root'
-      $master_config      = 'auto_master'
-      $map_config_dir     = '/etc'
-      $package_name       = [] # solaris has it built-in, no package required
-      $service_name       = 'autofs'
-      $service_hasrestart = true
-      $service_hasstatus  = true
+      $config_file_group   = 'root'
+      $config_file_owner   = 'root'
+      $master_config       = 'auto_master'
+      $map_config_dir      = '/etc'
+      $package_name        = [] # solaris has it built-in, no package required
+      $service_name        = 'autofs'
+      $service_hasrestart  = true
+      $service_hasstatus   = true
+      $supported_map_types = [ 'file', 'program' ]
+      $use_map_prefix      = false
     }
     'RedHat': {
-      $config_file_group  = 'root'
-      $config_file_owner  = 'root'
-      $master_config      = 'auto.master'
-      $map_config_dir     = '/etc'
-      $package_name       = [ 'autofs' ]
-      $service_name       = 'autofs'
-      $service_hasrestart = true
-      $service_hasstatus  = true
+      $config_file_group   = 'root'
+      $config_file_owner   = 'root'
+      $master_config       = 'auto.master'
+      $map_config_dir      = '/etc'
+      $package_name        = [ 'autofs' ]
+      $service_name        = 'autofs'
+      $service_hasrestart  = true
+      $service_hasstatus   = true
+      $supported_map_types = [ 'file', 'program', 'yp', 'nisplus', 'hesiod', 'ldap', 'ldaps' ]
+      $use_map_prefix      = true
     }
     'Archlinux': {
-      $config_file_group  = 'root'
-      $config_file_owner  = 'root'
-      $master_config      = 'auto.master'
-      $map_config_dir     = '/etc/autofs'
-      $package_name       = [ 'autofs' ]
-      $service_name       = 'autofs'
-      $service_hasrestart = true
-      $service_hasstatus  = true
+      $config_file_group   = 'root'
+      $config_file_owner   = 'root'
+      $master_config       = 'auto.master'
+      $map_config_dir      = '/etc/autofs'
+      $package_name        = [ 'autofs' ]
+      $service_name        = 'autofs'
+      $service_hasrestart  = true
+      $service_hasstatus   = true
+      $supported_map_types = [ 'file', 'program', 'yp', 'nisplus', 'hesiod', 'ldap', 'ldaps' ]
+      $use_map_prefix      = true
     }
     'Gentoo': {
-      $config_file_group  = 'root'
-      $config_file_owner  = 'root'
-      $master_config      = 'auto.master'
-      $map_config_dir     = '/etc/autofs'
-      $package_name       = [ 'net-fs/autofs' ]
-      $service_name       = 'autofs'
-      $service_hasrestart = true
-      $service_hasstatus  = true
+      $config_file_group   = 'root'
+      $config_file_owner   = 'root'
+      $master_config       = 'auto.master'
+      $map_config_dir      = '/etc/autofs'
+      $package_name        = [ 'net-fs/autofs' ]
+      $service_name        = 'autofs'
+      $service_hasrestart  = true
+      $service_hasstatus   = true
+      $supported_map_types = [ 'file', 'program', 'yp', 'nisplus', 'hesiod', 'ldap', 'ldaps' ]
+      $use_map_prefix      = true
     }
     default: {
       fail("osfamily not supported: ${::osfamily}")

--- a/spec/defines/autofs__mapfile_spec.rb
+++ b/spec/defines/autofs__mapfile_spec.rb
@@ -53,5 +53,22 @@ describe 'autofs::mapfile' do
       }
   end
 
+  describe 'with an invalid map type' do
+      let(:params) {{ :directory => '/foo' , :maptype => 'bar' }}
+      it { should raise_error(Puppet::Error, /maptype must be one of/) }
+  end
+
+  describe 'with a different map type' do
+      let(:params) {{ :directory => '/foo' , :maptype => 'program' }}
+      it { should_not raise_error }
+      it {
+          should contain_concat__fragment('auto.master/auto.foo').
+          with_content(/program:auto.foo/)
+      }
+      it {
+          should_not contain_concat('auto.foo')
+      }
+  end
+
 end
 


### PR DESCRIPTION
This allows a user to specify a non-`file` map type for an `autofs::mapfile`.
No content will be created for the map, and (in non-Solaris automount systems),
the map will be referenced with the map type prefix.

Example:
```puppet:
autofs::mapfile{ 'auto.chroot':
  directory => '/chroot',
  maptype   => program,
}
```

This would cause the `auto.master` file to include (in non-Solaris systems):

    /chroot program:auto.chroot

and would _not_ create the `/etc/auto.chroot` file (leaving that up to the user).