### PR TITLE
Fixes includes in Hiera config.

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,7 +4,7 @@ class autofs::config inherits autofs {
     directory => undef,
   }
 
-  create_resources('autofs::includes', $autofs::includes)
+  create_resources('autofs::include', $autofs::includes)
   create_resources('autofs::mapfile', $autofs::mapfiles)
   create_resources('autofs::mount', $autofs::mounts)
 }


### PR DESCRIPTION
A small typo breaks the include statements in the Hiera config for this module.